### PR TITLE
add Docker configuration and wait-for-db script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target
+.git
+.idea
+.vscode
+.mvn/wrapper/maven-wrapper.jar
+.m2
+node_modules
+**/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM maven:3.9.4-eclipse-temurin-21 AS build
+WORKDIR /build
+
+# Cache dependencies
+COPY pom.xml ./
+COPY mvnw .
+COPY .mvn .mvn
+RUN mvn -B -DskipTests dependency:go-offline || true
+
+# Copy sources and build
+COPY src ./src
+RUN mvn -B -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /build/target/*.jar app.jar
+COPY docker/wait-for-db.sh /usr/local/bin/wait-for-db.sh
+RUN chmod +x /usr/local/bin/wait-for-db.sh
+
+EXPOSE 8080
+
+VOLUME ["/app/images"]
+
+ENTRYPOINT ["/usr/local/bin/wait-for-db.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: shelflife
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    volumes:
+      - ./.env:/app/.env:ro
+      - ./images:/app/images
+    environment:
+      - SPRING_CONFIG_IMPORT=file:.env[.properties]
+      - DB_HOST=db
+      - DB_PORT=3306
+      - DB_WAIT_TIMEOUT=60
+
+volumes:
+  db_data:

--- a/docker/wait-for-db.sh
+++ b/docker/wait-for-db.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_HOST="${DB_HOST:-db}"
+DB_PORT="${DB_PORT:-3306}"
+DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
+
+echo "Waiting for database $DB_HOST:$DB_PORT (timeout=${DB_WAIT_TIMEOUT}s)"
+start_time=$(date +%s)
+while true; do
+  if bash -c "</dev/tcp/${DB_HOST}/${DB_PORT}" >/dev/null 2>&1; then
+    echo "$DB_HOST:$DB_PORT is available"
+    break
+  fi
+  now=$(date +%s)
+  if [ $((now - start_time)) -ge "$DB_WAIT_TIMEOUT" ]; then
+    echo "Timed out waiting for ${DB_HOST}:${DB_PORT} after ${DB_WAIT_TIMEOUT}s" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+exec java -jar /app/app.jar


### PR DESCRIPTION
This pull request adds full Docker support for local development and deployment, including Dockerfiles, a docker-compose setup, and supporting scripts. The changes enable the application and its MySQL database to be spun up easily in containers, improve developer experience, and standardize environment configuration.

**Dockerization and Container Orchestration:**

* Added a `Dockerfile` that builds the application using Maven, sets up the runtime environment, copies a database wait script, and configures the container entrypoint and volume mounts.
* Added a `docker-compose.yml` file to orchestrate the application and a MySQL database, with environment variables, persistent volumes, health checks, and port mappings for both services.

**Supporting Scripts and Configuration:**

* Added a `docker/wait-for-db.sh` script to ensure the application container waits for the database to become available before starting, preventing startup errors due to database unavailability.
* Created a `.dockerignore` file to exclude unnecessary files and directories (such as build artifacts, version control, and IDE files) from the Docker build context, reducing image size and build time.